### PR TITLE
small typo in line 93

### DIFF
--- a/Stabilize.cpp
+++ b/Stabilize.cpp
@@ -90,7 +90,7 @@ void threadStabilizer_callback(){
 	}
 
 	// Check if dt is good to go
-	if(dt <= 0.0 && dt >= 0.2){
+	if(dt <= 0.0 || dt >= 0.2){
 		LOG("$ dt too high! "); LOG(dt); LOG("\n");
 		return;
 	}


### PR DESCRIPTION
line 93 -- small typo changing && for || since this line is checking if the delta time is small/equal to 0 OR greater/equal than 0.2
